### PR TITLE
perf: replace PowerShell/CIM process queries with in-process psutil scans

### DIFF
--- a/service/core.py
+++ b/service/core.py
@@ -21,6 +21,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+import psutil
+
 from . import studio_guard
 from . import studio_uia
 from .deploy_lock import DeployLock
@@ -2804,19 +2806,18 @@ def _bridge_owner_pid(cfg: Config, runner: Runner = _DEFAULT_RUNNER) -> int | No
     """PID owning the bridge's TCP listener — i.e. the Studio instance HOSTING the
     design-time bridge (the bridge NetLogic runs inside that Studio process). Used by
     save() to target Ctrl+S at the SAME instance the bridge authored into.
-    Windows-only (Get-NetTCPConnection); returns None if not resolvable."""
+    In-process psutil scan (was a Get-NetTCPConnection PowerShell spawn — one of
+    the per-restart process-spawn costs); `runner` is kept for signature
+    stability. Returns None if not resolvable."""
     port = _bridge_port(cfg)
-    ps = (
-        f"$c = Get-NetTCPConnection -LocalPort {port} -State Listen "
-        f"-ErrorAction SilentlyContinue | Select-Object -First 1; "
-        f"if ($c) {{ Write-Output $c.OwningProcess }}"
-    )
     try:
-        proc = runner.run_powershell(ps, timeout=10)
-    except Exception:
+        for c in psutil.net_connections(kind="tcp"):
+            if (c.status == psutil.CONN_LISTEN and c.laddr
+                    and c.laddr.port == port and c.pid):
+                return c.pid
+    except (psutil.Error, OSError):
         return None
-    s = (proc.stdout or "").strip()
-    return int(s) if s.isdigit() else None
+    return None
 
 
 def _gentle_focus() -> bool:
@@ -3385,18 +3386,46 @@ def run_emulator(
 def _bare_runtime_running(cfg: Config, runner: Runner = _DEFAULT_RUNNER) -> bool:
     """Any FTOptixRuntime.exe process at all — the identity-agnostic fallback for
     run_emulator's spawn check. The strict --application-name=Emulator match in
-    emulator_status can miss a just-F5'd runtime whose CommandLine isn't in CIM
-    yet, or lag on a busy box; a bare presence check tells 'still starting' apart
+    emulator_status can miss a just-F5'd runtime whose command line isn't
+    readable yet; a bare presence check tells 'still starting' apart
     from 'nothing spawned'. Best-effort; returns False on any error.
     """
-    ps = ("$p = Get-Process FTOptixRuntime -ErrorAction SilentlyContinue; "
-          "if ($p) { 'RUNTIMES=' + $p.Count } else { 'RUNTIMES=0' }")
     try:
-        proc = runner.run_powershell(ps, timeout=15)
-        m = re.search(r"RUNTIMES=(\d+)", proc.stdout or "")
-        return bool(m) and int(m.group(1)) > 0
-    except Exception:
-        return False
+        for p in psutil.process_iter(["name"]):
+            if (p.info.get("name") or "").lower() == "ftoptixruntime.exe":
+                return True
+    except psutil.Error:
+        pass
+    return False
+
+
+def _emulator_pids() -> list[int]:
+    """PIDs of FTOptixRuntime.exe instances launched with
+    `--application-name=Emulator` — the command-line discriminator that
+    separates the emulator from an UpdateSvc-deployed runtime (same exe,
+    typically same port). In-process psutil scan; the previous
+    Get-CimInstance Win32_Process PowerShell spawn cost seconds per call and
+    ran up to four times per restart. Best-effort: unreadable processes are
+    skipped, any scan failure returns [].
+    """
+    pids: list[int] = []
+    try:
+        # Name-only iteration first (cheap toolhelp snapshot); read cmdline
+        # ONLY for actual FTOptixRuntime processes. Asking process_iter for
+        # "cmdline" up front queries EVERY process on the box and the
+        # access-denied fallbacks make that take tens of seconds unelevated.
+        for p in psutil.process_iter(["pid", "name"]):
+            if (p.info.get("name") or "").lower() != "ftoptixruntime.exe":
+                continue
+            try:
+                cmd = " ".join(p.cmdline())
+            except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+                continue
+            if "--application-name=Emulator" in cmd:
+                pids.append(p.info["pid"])
+    except psutil.Error:
+        pass
+    return pids
 
 
 def emulator_status(cfg: Config, runner: Runner = _DEFAULT_RUNNER) -> dict:
@@ -3405,11 +3434,8 @@ def emulator_status(cfg: Config, runner: Runner = _DEFAULT_RUNNER) -> dict:
     F5 in Studio TOGGLES the emulator, so a caller needs the current state to
     avoid a blind start-that-actually-stops.
 
-    Discriminates the EMULATOR from other FTOptixRuntime.exe instances — the
-    UpdateSvc-deployed runtime is the SAME exe, typically on the SAME port, so a
-    name-only process match reports "running" for a deployed app when no emulator
-    exists. Studio launches the emulator with
-    `--application-name=Emulator` on its command line; only those PIDs count.
+    Discriminates the EMULATOR from other FTOptixRuntime.exe instances via
+    _emulator_pids (see there); `runner` is kept for signature stability.
 
     States:
       not_running — no emulator process
@@ -3421,18 +3447,7 @@ def emulator_status(cfg: Config, runner: Runner = _DEFAULT_RUNNER) -> dict:
     is kept as a bool for back-compat and is True only in the `running` state.
     Adds a `hint` when the port is served by something that is NOT the emulator.
     """
-    ps = ("$p = Get-CimInstance Win32_Process -Filter \"Name='FTOptixRuntime.exe'\" "
-          "-ErrorAction SilentlyContinue | "
-          "Where-Object { $_.CommandLine -match '--application-name=Emulator' }; "
-          "if ($p) { 'PIDS=' + (($p | ForEach-Object { $_.ProcessId }) -join ',') } else { 'PIDS=' }")
-    pids: list[int] = []
-    try:
-        proc = runner.run_powershell(ps, timeout=15)
-        m = re.search(r"PIDS=([\d,]*)", (proc.stdout or ""))
-        if m and m.group(1):
-            pids = [int(x) for x in m.group(1).split(",") if x]
-    except Exception:
-        pass
+    pids = _emulator_pids()
     port = runtime_probe_port(cfg)
     reachable = _tcp_probe(runtime_probe_host(cfg), port)
     if pids and reachable:
@@ -3594,7 +3609,7 @@ def restart_emulator(
     st = emulator_status(cfg, runner)
     stopped = None
     if st.get("pids"):
-        stopped = stop_emulator(cfg, runner)
+        stopped = stop_emulator(cfg, runner, status=st)
     out = run_emulator(cfg, project, save_first=False, wait_ready=True, runner=runner)
     out["restarted"] = bool(st.get("pids"))
     if stopped is not None:
@@ -3615,24 +3630,35 @@ def _emulator_state_cached(cfg: Config, ttl: float = 5.0) -> dict:
     return _EMU_STATE_CACHE["v"]
 
 
-def stop_emulator(cfg: Config, runner: Runner = _DEFAULT_RUNNER) -> dict:
+def stop_emulator(
+    cfg: Config, runner: Runner = _DEFAULT_RUNNER, status: dict | None = None,
+) -> dict:
     """Stop the local FTOptixRuntime emulator by terminating its process(es).
 
     An explicit, unambiguous stop — vs F5, which toggles and is easy to double-fire.
-    Terminates ONLY emulator instances (CommandLine-matched via emulator_status);
+    Terminates ONLY emulator instances (command-line-matched via emulator_status);
     an UpdateSvc-deployed runtime is the same exe and is deliberately left alone.
+    `status` lets a caller that JUST ran emulator_status (restart_emulator) hand
+    the result in instead of paying a second scan. Kill is TerminateProcess
+    (same semantics as the old Stop-Process -Force), then a short wait so the
+    post-kill re-check doesn't race the process teardown.
     Returns {stopped, killed_pids, still_running}.
     """
     audit(cfg, "emulator_stop")
-    st = emulator_status(cfg, runner)
+    st = status if status is not None else emulator_status(cfg, runner)
     if not st["pids"]:  # pids, not `running` — a "starting" emulator must be stoppable
         return {"stopped": False, "reason": "not_running", "killed_pids": []}
-    ids = ",".join(str(p) for p in st["pids"])
+    procs = []
     try:
-        runner.run_powershell(
-            f"Stop-Process -Id {ids} -Force -ErrorAction SilentlyContinue",
-            timeout=15)
-    except Exception as e:
+        for pid in st["pids"]:
+            try:
+                p = psutil.Process(pid)
+                p.kill()
+                procs.append(p)
+            except psutil.NoSuchProcess:
+                pass  # already gone — that's a successful stop
+        psutil.wait_procs(procs, timeout=5)
+    except psutil.Error as e:
         return {"stopped": False, "reason": f"stop_failed: {e}", "killed_pids": []}
     after = emulator_status(cfg, runner)
     return {"stopped": not after["pids"], "killed_pids": st["pids"],

--- a/service/main.py
+++ b/service/main.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import asyncio
 import socket
 import sys
+import threading
 from collections.abc import Awaitable, Callable
 from typing import Any
 
@@ -270,6 +271,13 @@ def main(argv: list[str] | None = None) -> int:
         for line in fails:
             print(line, file=sys.stderr, flush=True)
         return exit_code
+
+    # Warm psutil's process map off the request path: the FIRST process_iter
+    # can take tens of seconds (per-process handle opens, slower still when
+    # endpoint-protection hooks them), every later scan ~0.1s. Without this,
+    # the first emulator status/stop/restart after service boot eats that
+    # cold hit.
+    threading.Thread(target=core._emulator_pids, daemon=True).start()
 
     http_app: Any = make_app(cfg)
     mcp = make_mcp(cfg)

--- a/service/tests/test_composites.py
+++ b/service/tests/test_composites.py
@@ -12,7 +12,7 @@ def test_restart_emulator_stops_then_runs(cfg: core.Config, monkeypatch) -> None
     monkeypatch.setattr(core, "emulator_status",
                         lambda c, r=None: {"pids": [111], "state": "running"})
     monkeypatch.setattr(core, "stop_emulator",
-                        lambda c, r=None: calls.append("stop") or {"stopped": True, "killed_pids": [111]})
+                        lambda c, r=None, status=None: calls.append("stop") or {"stopped": True, "killed_pids": [111]})
     monkeypatch.setattr(core, "run_emulator",
                         lambda c, p, save_first=False, wait_ready=True, runner=None:
                         calls.append("run") or {"launched": True, "serving": True})
@@ -26,7 +26,7 @@ def test_restart_emulator_skips_stop_when_idle(cfg: core.Config, monkeypatch) ->
     monkeypatch.setattr(core, "emulator_status",
                         lambda c, r=None: {"pids": [], "state": "not_running"})
     monkeypatch.setattr(core, "stop_emulator",
-                        lambda c, r=None: (_ for _ in ()).throw(AssertionError("no stop when idle")))
+                        lambda c, r=None, status=None: (_ for _ in ()).throw(AssertionError("no stop when idle")))
     monkeypatch.setattr(core, "run_emulator",
                         lambda c, p, save_first=False, wait_ready=True, runner=None:
                         {"launched": True, "serving": True})

--- a/service/tests/test_run_emulator.py
+++ b/service/tests/test_run_emulator.py
@@ -16,6 +16,15 @@ def _no_bridge_by_default(monkeypatch) -> None:
     monkeypatch.setattr(core, "_use_bridge_for", lambda cfg, project: False)
 
 
+@pytest.fixture(autouse=True)
+def _no_host_runtime(monkeypatch) -> None:
+    """The bare-presence fallback scans REAL host processes (psutil) — a live
+    FTOptixRuntime on the test host would flip the no-spawn diagnosis tests
+    to 'starting'. Tests exercising the True path override this stub."""
+    monkeypatch.setattr(core, "_bare_runtime_running",
+                        lambda cfg, runner=None: False)
+
+
 def _proj(projects_root: Path) -> None:
     make_project(projects_root, "Alpha")
 
@@ -104,23 +113,50 @@ def _mock_port(monkeypatch, reachable: bool) -> None:
     monkeypatch.setattr(_socket, "socket", lambda *a, **k: FakeSock())
 
 
+class _PsProc:
+    """Minimal stand-in for a psutil.process_iter(attrs=...) element.
+    cmdline=None models an unreadable process (cmdline() raises AccessDenied,
+    like the real psutil object)."""
+
+    def __init__(self, pid: int, name: str, cmdline: list[str] | None) -> None:
+        self.info = {"pid": pid, "name": name}
+        self._cmdline = cmdline
+
+    def cmdline(self) -> list[str]:
+        if self._cmdline is None:
+            raise core.psutil.AccessDenied(self.info["pid"])
+        return self._cmdline
+
+
+def _mock_procs(monkeypatch, procs: list[_PsProc]) -> None:
+    monkeypatch.setattr(core.psutil, "process_iter",
+                        lambda attrs=None, ad_value=None: iter(procs))
+
+
+_EMU_CMD = ["FTOptixRuntime.exe", "--application-name=Emulator"]
+_DEPLOYED_CMD = ["FTOptixRuntime.exe", "--application-name=Deployed"]
+
+
 def test_emulator_status_running_needs_pid_and_port(cfg: core.Config, monkeypatch) -> None:
-    """running requires BOTH an emulator PID and the port serving."""
+    """running requires BOTH an emulator PID and the port serving; the PID scan
+    must be command-line-discriminated (a deployed runtime is the same exe)."""
     _mock_port(monkeypatch, reachable=True)
-    runner = make_fake_runner(lambda cmd, kw: FakeProc(0, "PIDS=1234,5678"))
-    st = core.emulator_status(cfg, runner=runner)
+    _mock_procs(monkeypatch, [
+        _PsProc(1234, "FTOptixRuntime.exe", _EMU_CMD),
+        _PsProc(5678, "FTOptixRuntime.exe", _EMU_CMD),
+        _PsProc(9999, "FTOptixRuntime.exe", _DEPLOYED_CMD),  # must NOT count
+        _PsProc(42, "notepad.exe", ["notepad.exe"]),
+    ])
+    st = core.emulator_status(cfg)
     assert st["state"] == "running" and st["running"] is True
     assert st["pids"] == [1234, 5678] and st["port_reachable"] is True
-    # the PID probe must be CommandLine-discriminated, not a name-only match
-    ps = runner.calls[0][0][-1]
-    assert "--application-name=Emulator" in ps and "Get-CimInstance" in ps
 
 
 def test_emulator_status_starting_when_port_not_serving(cfg: core.Config, monkeypatch) -> None:
     """PID up but port down = starting, NOT running (the pre-1.1 false positive)."""
     _mock_port(monkeypatch, reachable=False)
-    runner = make_fake_runner(lambda cmd, kw: FakeProc(0, "PIDS=1234"))
-    st = core.emulator_status(cfg, runner=runner)
+    _mock_procs(monkeypatch, [_PsProc(1234, "FTOptixRuntime.exe", _EMU_CMD)])
+    st = core.emulator_status(cfg)
     assert st["state"] == "starting" and st["running"] is False
     assert "hint" in st
 
@@ -129,8 +165,8 @@ def test_emulator_status_deployed_runtime_is_not_emulator(cfg: core.Config, monk
     """Port serving but no emulator PID (an UpdateSvc-deployed runtime holds the
     port) = not_running with a hint — the 2026-07-16 false-positive trap."""
     _mock_port(monkeypatch, reachable=True)
-    runner = make_fake_runner(lambda cmd, kw: FakeProc(0, "PIDS="))
-    st = core.emulator_status(cfg, runner=runner)
+    _mock_procs(monkeypatch, [_PsProc(9999, "FTOptixRuntime.exe", _DEPLOYED_CMD)])
+    st = core.emulator_status(cfg)
     assert st["state"] == "not_running" and st["running"] is False
     assert st["port_reachable"] is True
     assert "hint" in st and "deployed" in st["hint"].lower()
@@ -138,26 +174,49 @@ def test_emulator_status_deployed_runtime_is_not_emulator(cfg: core.Config, monk
 
 def test_emulator_status_not_running(cfg: core.Config, monkeypatch) -> None:
     _mock_port(monkeypatch, reachable=False)
-    runner = make_fake_runner(lambda cmd, kw: FakeProc(0, "PIDS="))
-    st = core.emulator_status(cfg, runner=runner)
+    _mock_procs(monkeypatch, [])
+    st = core.emulator_status(cfg)
     assert st["state"] == "not_running" and st["running"] is False and st["pids"] == []
+
+
+def test_emulator_status_survives_unreadable_cmdline(cfg: core.Config, monkeypatch) -> None:
+    """A process whose cmdline read raises AccessDenied must be skipped,
+    not crash the scan."""
+    _mock_port(monkeypatch, reachable=False)
+    _mock_procs(monkeypatch, [
+        _PsProc(7, "FTOptixRuntime.exe", None),
+        _PsProc(1234, "FTOptixRuntime.exe", _EMU_CMD),
+    ])
+    st = core.emulator_status(cfg)
+    assert st["pids"] == [1234]
+
+
+def _mock_kill(monkeypatch, state: dict, killed: list[int]) -> None:
+    """Fake psutil.Process/wait_procs: record kills, flip state['stopped']."""
+    class FakePs:
+        def __init__(self, pid: int) -> None:
+            self.pid = pid
+
+        def kill(self) -> None:
+            killed.append(self.pid)
+            state["stopped"] = True
+
+    monkeypatch.setattr(core.psutil, "Process", FakePs)
+    monkeypatch.setattr(core.psutil, "wait_procs",
+                        lambda procs, timeout=None: (list(procs), []))
 
 
 def test_stop_emulator_kills_running(cfg: core.Config, monkeypatch) -> None:
     _mock_port(monkeypatch, reachable=True)
     state = {"stopped": False}
-
-    def handler(cmd, kw):
-        c = cmd[-1]
-        if "Stop-Process -Id" in c:
-            assert "1234" in c  # kills the discriminated PIDs, not every FTOptixRuntime
-            state["stopped"] = True
-            return FakeProc(0, "")
-        if "Get-CimInstance" in c:
-            return FakeProc(0, "PIDS=" if state["stopped"] else "PIDS=1234")
-        return FakeProc(0, "")
-
-    out = core.stop_emulator(cfg, runner=make_fake_runner(handler))
+    killed: list[int] = []
+    monkeypatch.setattr(
+        core, "_emulator_pids",
+        lambda: [] if state["stopped"] else [1234])
+    _mock_kill(monkeypatch, state, killed)
+    out = core.stop_emulator(cfg)
+    # kills the discriminated PIDs, not every FTOptixRuntime
+    assert killed == [1234]
     assert out["stopped"] is True and out["killed_pids"] == [1234]
 
 
@@ -165,25 +224,32 @@ def test_stop_emulator_stops_a_starting_emulator(cfg: core.Config, monkeypatch) 
     """A PID with the port not yet serving (state=starting) must still be stoppable."""
     _mock_port(monkeypatch, reachable=False)
     state = {"stopped": False}
-
-    def handler(cmd, kw):
-        c = cmd[-1]
-        if "Stop-Process -Id" in c:
-            state["stopped"] = True
-            return FakeProc(0, "")
-        if "Get-CimInstance" in c:
-            return FakeProc(0, "PIDS=" if state["stopped"] else "PIDS=4321")
-        return FakeProc(0, "")
-
-    out = core.stop_emulator(cfg, runner=make_fake_runner(handler))
+    killed: list[int] = []
+    monkeypatch.setattr(
+        core, "_emulator_pids",
+        lambda: [] if state["stopped"] else [4321])
+    _mock_kill(monkeypatch, state, killed)
+    out = core.stop_emulator(cfg)
     assert out["stopped"] is True and out["killed_pids"] == [4321]
 
 
 def test_stop_emulator_when_not_running(cfg: core.Config, monkeypatch) -> None:
     _mock_port(monkeypatch, reachable=False)
-    runner = make_fake_runner(lambda cmd, kw: FakeProc(0, "PIDS="))
-    out = core.stop_emulator(cfg, runner=runner)
+    monkeypatch.setattr(core, "_emulator_pids", lambda: [])
+    out = core.stop_emulator(cfg)
     assert out["stopped"] is False and out["reason"] == "not_running"
+
+
+def test_stop_emulator_uses_prefetched_status(cfg: core.Config, monkeypatch) -> None:
+    """status= skips the redundant scan restart_emulator already paid for."""
+    _mock_port(monkeypatch, reachable=False)
+    state = {"stopped": True}  # live scan says gone (post-kill re-check)
+    killed: list[int] = []
+    monkeypatch.setattr(core, "_emulator_pids", lambda: [])
+    _mock_kill(monkeypatch, state, killed)
+    out = core.stop_emulator(cfg, status={"pids": [1234]})
+    assert killed == [1234]
+    assert out["stopped"] is True and out["killed_pids"] == [1234]
 
 
 # --- F5 target guard (2026-07-17): F5 runs the SELECTED deployment target ---

--- a/service/tests/test_runtime_attach.py
+++ b/service/tests/test_runtime_attach.py
@@ -125,8 +125,8 @@ def test_emulator_status_unset_probes_loopback(cfg: core.Config, monkeypatch) ->
         return True
 
     monkeypatch.setattr(core, "_tcp_probe", fake_probe)
-    runner = make_fake_runner(lambda cmd, kw: FakeProc(0, "PIDS=1234"))
-    st = core.emulator_status(cfg, runner=runner)
+    monkeypatch.setattr(core, "_emulator_pids", lambda: [1234])
+    st = core.emulator_status(cfg)
     assert seen["host"] == "127.0.0.1"
     assert seen["port"] == cfg.runtime_test_port
     assert st["port"] == cfg.runtime_test_port


### PR DESCRIPTION
## Problem

Every emulator lifecycle call (status/stop/restart) spawned fresh `powershell.exe` processes — up to 7 per restart, 4 of them `Get-CimInstance Win32_Process` WMI queries at 2-4s each. Roughly 10-20s of pure overhead per restart cycle on top of Studio's own build time. Slow scans could also starve the HTTP threadpool, hanging `/health` and the `/ui` dashboard.

## Changes

- `_emulator_pids()`: in-process psutil scan replaces the CIM PowerShell spawn. Name-filtered iteration first, `cmdline()` read only for actual FTOptixRuntime.exe matches — asking `process_iter` for cmdline on every process costs tens of seconds unelevated (per-process access-denied fallbacks).
- `_bare_runtime_running` / `_bridge_owner_pid`: psutil scans replace `Get-Process` / `Get-NetTCPConnection` spawns.
- `stop_emulator`: kills via `psutil.Process.kill()` (same TerminateProcess semantics as `Stop-Process -Force`) + `wait_procs` so the post-kill re-check does not race teardown. New optional `status=` param lets `restart_emulator` hand in the status it already fetched instead of paying a second scan.
- `main.py`: psutil process-map warmup in a daemon thread at service boot — the first-ever `process_iter` can cost ~20s (per-process handle opens, worse under endpoint protection); later scans are ~0.1s. Keeps the cold hit off the first request.
- Only remaining PowerShell spawn in the restart path is the F5 focus/keystroke script, which is inherently a shell operation.

Command-line discrimination is unchanged: only `--application-name=Emulator` processes count, UpdateSvc-deployed runtimes (same exe) are never touched.

## Measured (Win10, unelevated service)

- `emulator_status`: 2-4s per call -> ~0.6s cold / ~0.15s warm
- restart cycle overhead: 10-20s -> sub-second (Studio build time unchanged)
- `/health`: hang -> 7ms

## Tests

Status/stop tests rewritten against faked `psutil.process_iter`/`Process`; added coverage for AccessDenied-cmdline skip and the prefetched-status path; autouse stub keeps a live FTOptixRuntime on the test host from flipping the no-spawn diagnosis tests. Full suite green: 850 passed, 15 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)